### PR TITLE
Recent leaves

### DIFF
--- a/cmd/arbor/main.go
+++ b/cmd/arbor/main.go
@@ -35,6 +35,11 @@ func main() {
 	toWelcome := make(chan chan<- *ProtocolMessage)
 	go handleWelcomes(m.UUID, recents, toWelcome)
 	log.Println("Root message UUID is " + m.UUID)
+
+	// Forever listen for incoming connections
+	// If connection recieved, add to broadcaster list,
+	// start a client connection goroutine,
+	// and send welcome message
 	for {
 		conn, err := listener.Accept()
 		if err != nil {
@@ -64,6 +69,7 @@ func handleWelcomes(rootId string, recents *RecentList, toWelcome chan chan<- *P
 	}
 }
 
+// handleClient is a goroutine that is instantiated for every client.
 func handleClient(from <-chan *ProtocolMessage, to chan<- *ProtocolMessage, recents *RecentList, store *Store, broadcaster *Broadcaster) {
 	for message := range from {
 		switch message.Type {
@@ -96,7 +102,7 @@ func handleNewMessage(msg *ProtocolMessage, recents *RecentList, store *Store, b
 	if err != nil {
 		log.Println("Error creating new message", err)
 	}
-	recents.Add(msg.ChatMessage.UUID)
+	recents.Add(msg.ChatMessage)
 	store.Add(msg.ChatMessage)
 	broadcaster.Send(msg)
 }

--- a/cmd/arbor/main.go
+++ b/cmd/arbor/main.go
@@ -11,8 +11,11 @@ import (
 func main() {
 	messages := NewStore()
 	broadcaster := NewBroadcaster()
-	recents := NewRecents(10)
 	address := ":7777"
+	recents, err := NewRecents(10)
+	if err != nil {
+		log.Fatalln("Unable to initialize Recents", err)
+	}
 	//serve
 	if len(os.Args) > 1 {
 		address = os.Args[1]

--- a/cmd/arbor/main.go
+++ b/cmd/arbor/main.go
@@ -99,7 +99,7 @@ func handleNewMessage(msg *ProtocolMessage, recents *RecentList, store *Store, b
 	if err != nil {
 		log.Println("Error creating new message", err)
 	}
-	recents.Add(msg.ChatMessage.UUID)
+	recents.Add(msg.ChatMessage)
 	store.Add(msg.ChatMessage)
 	broadcaster.Send(msg)
 }

--- a/cmd/arbor/recents.go
+++ b/cmd/arbor/recents.go
@@ -1,6 +1,5 @@
 package main
 
-import "log"
 import messages "github.com/arborchat/arbor-go"
 
 // The RecentList structure is designed to be completely threadsafe
@@ -43,7 +42,7 @@ func (r *RecentList) dispatch() {
 		case msg := <-r.add:
 			// If parent message is in recent list,
 			parentIndex := -1
-			for i := 0; i < r.index; i++ {
+			for i := range r.recents {
 				if msg.Parent == r.recents[i] {
 					parentIndex = i
 					break
@@ -53,7 +52,6 @@ func (r *RecentList) dispatch() {
 			if parentIndex > 0 {
 				id := msg.UUID
 				r.recents[parentIndex] = id
-				log.Println("replaceing recent message " + msg.Parent + " with " + msg.UUID)
 			} else {
 				id := msg.UUID
 				r.recents[r.index] = id

--- a/cmd/arbor/recents.go
+++ b/cmd/arbor/recents.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 
 	messages "github.com/arborchat/arbor-go"
 )
@@ -47,7 +48,7 @@ func (r *RecentList) dispatch() {
 		select {
 		// Add function called
 		case msg := <-r.add:
-			if r.removeParent(msg) && len(r.recents) < cap(r.recents) {
+			if !r.removeParent(msg) && len(r.recents) < cap(r.recents) {
 				// Resize slice
 				r.recents = r.recents[:len(r.recents)+1]
 			}
@@ -96,8 +97,8 @@ func (r *RecentList) removeParent(msg *messages.ChatMessage) bool {
 	parentIndex := -1
 
 	// Locate parent
-	for i := 0; parentIndex >= 0 && i < len(r.recents); i++ {
-		if parentID == r.recents[i] {
+	for i := 0; parentIndex < 0 && i < cap(r.recents); i++ {
+		if r.recents[i] == parentID {
 			parentIndex = i
 		}
 	}
@@ -105,13 +106,18 @@ func (r *RecentList) removeParent(msg *messages.ChatMessage) bool {
 	// Remove parent
 	if parentIndex >= 0 {
 		// Remove elements
-		for i := parentIndex; i != r.index; i = (i + 1) % len(r.recents) {
-			r.recents[i] = r.recents[(i+1)%len(r.recents)]
+		for i := parentIndex; i != r.index; i = (i + 1) % cap(r.recents) {
+			log.Printf("i:       %d\n", i)
+			log.Printf("index:   %d\n", r.index)
+			log.Printf("recents: %d\n", cap(r.recents))
+			log.Println()
+			r.recents[i] = r.recents[(i+1)%cap(r.recents)]
 		}
+
 		// Fix index
 		r.index--
 		if r.index < 0 {
-			r.index = len(r.recents) - 1
+			r.index = cap(r.recents) - 1
 		}
 	}
 

--- a/cmd/arbor/recents.go
+++ b/cmd/arbor/recents.go
@@ -49,7 +49,7 @@ func (r *RecentList) dispatch() {
 				}
 			}
 			// it is replaced by the new message.
-			if parentIndex > 0 {
+			if parentIndex >= 0 {
 				id := msg.UUID
 				r.recents[parentIndex] = id
 			} else {

--- a/cmd/arbor/recents.go
+++ b/cmd/arbor/recents.go
@@ -61,7 +61,7 @@ func (r *RecentList) dispatch() {
 				}
 				r.index %= len(r.recents)
 			}
-		// Data method called
+		// Data function called
 		case <-r.reqData:
 			buflen := r.index
 			if r.full {

--- a/cmd/arbor/recents.go
+++ b/cmd/arbor/recents.go
@@ -50,11 +50,11 @@ func (r *RecentList) dispatch() {
 			}
 			// it is replaced by the new message.
 			if parentIndex >= 0 {
-    			// Shift from the parent index to the end of the queue
-    			// to preserve FIFO rule
-    			for i := parentIndex; i != r.index;{
-        			r.recents[i] = r.recents[++i %= len(r.recents)]
-    			}
+				// Shift from the parent index to the end of the queue
+				// to preserve FIFO rule
+				for i := parentIndex; i != r.index; i = (i + 1) % len(r.recents) {
+					r.recents[i] = r.recents[(i+1)%len(r.recents)]
+				}
 			}
 
 			id := msg.UUID

--- a/cmd/arbor/recents.go
+++ b/cmd/arbor/recents.go
@@ -106,12 +106,12 @@ func (r *RecentList) removeParent(msg *messages.ChatMessage) bool {
 	// Remove parent
 	if parentIndex >= 0 {
 		// Remove elements
-		for i := parentIndex; i != r.index; i = (i + 1) % cap(r.recents) {
+		for i := parentIndex; i != r.index; i = (i + 1) % len(r.recents) {
 			log.Printf("i:       %d\n", i)
 			log.Printf("index:   %d\n", r.index)
-			log.Printf("recents: %d\n", cap(r.recents))
+			log.Printf("recents: %d\n", len(r.recents))
 			log.Println()
-			r.recents[i] = r.recents[(i+1)%cap(r.recents)]
+			r.recents[i] = r.recents[(i+1)%len(r.recents)]
 		}
 
 		// Fix index

--- a/cmd/arbor/recents.go
+++ b/cmd/arbor/recents.go
@@ -53,8 +53,8 @@ func (r *RecentList) dispatch() {
 	}
 }
 
-func (r *RecentList) Add(id string) {
-	r.add <- id
+func (r *RecentList) Add(msg *messages.ChatMessage) {
+	r.add <- msg.UUID
 }
 
 func (r *RecentList) Data() []string {

--- a/cmd/arbor/recents.go
+++ b/cmd/arbor/recents.go
@@ -50,17 +50,20 @@ func (r *RecentList) dispatch() {
 			}
 			// it is replaced by the new message.
 			if parentIndex > 0 {
-				id := msg.UUID
-				r.recents[parentIndex] = id
-			} else {
-				id := msg.UUID
-				r.recents[r.index] = id
-				r.index++
-				if !r.full && r.index == len(r.recents) {
-					r.full = true
-				}
-				r.index %= len(r.recents)
+    			// Shift from the parent index to the end of the queue
+    			for i := parentIndex; i != r.index;{
+        			r.recents[i] = r.recents[++i %= len(r.recents)]
+    			}
 			}
+
+			id := msg.UUID
+			r.recents[r.index] = id
+			r.index++
+			if !r.full && r.index == len(r.recents) {
+				r.full = true
+			}
+			r.index %= len(r.recents)
+
 		// Data method called
 		case <-r.reqData:
 			buflen := r.index

--- a/cmd/arbor/recents_test.go
+++ b/cmd/arbor/recents_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+	"log"
 	"testing"
 
 	. "github.com/arborchat/arbor-go"
@@ -36,19 +38,20 @@ func TestRecentListRemoveParentVacancy(t *testing.T) {
 	if err != nil {
 		t.Skip("Failed to create RecentList", err)
 	}
+	g.Expect(r.Data()).Should(gomega.BeEmpty())
 
 	m0, err := NewChatMessage("message 0")
 	if err != nil {
 		t.Skip("Failed to create message")
 	}
-	m0.AssignID()
+	m0.UUID = "first"
 	r.Add(m0)
 
 	m1, err := m0.Reply("message1")
 	if err != nil {
 		t.Skip("Failed to reply to message")
 	}
-	m1.AssignID()
+	m1.UUID = "second"
 
 	for i := 0; i < 7; i++ {
 		r.Add(m1)
@@ -59,7 +62,10 @@ func TestRecentListRemoveParentVacancy(t *testing.T) {
 		if err != nil {
 			t.Skip("Failed to reply to message")
 		}
-		m1.AssignID()
+		m1.UUID = fmt.Sprintf("%dth", i+3)
+		log.Printf("message %d added", i)
+		log.Printf("M0: %s", m0.UUID)
+		log.Printf("M1: %s", m1.UUID)
 	}
 }
 

--- a/cmd/arbor/recents_test.go
+++ b/cmd/arbor/recents_test.go
@@ -28,36 +28,93 @@ func TestRecentListConstructor(t *testing.T) {
 	g.Expect(data).To(gomega.BeEmpty())
 }
 
-func TestRecentListRemoveParent(t *testing.T) {
+// TestRecemtListRemoveParentVacancy tests that a parent message is replaced when
+// a its child is added to the RecentList, before the queue is full
+func TestRecentListRemoveParentVacancy(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	r1, _ := NewRecents(5)
-	r2, _ := NewRecents(5)
+	r, err := NewRecents(5)
+	if err != nil {
+		t.Skip("Failed to create RecentList", err)
+	}
 
-	m0, _ := NewChatMessage("message 0")
+	m0, err := NewChatMessage("message 0")
+	if err != nil {
+		t.Skip("Failed to create message")
+	}
 	m0.AssignID()
-	r1.Add(m0)
-	r2.Add(m0)
+	r.Add(m0)
 
-	// r1 contains m1 with no parent ID
-	// r2 contains m1 with m0 as parent
-	// so m0 should be removed from recents
-	m1, _ := NewChatMessage("message 1")
+	m1, err := m0.Reply("message1")
+	if err != nil {
+		t.Skip("Failed to reply to message")
+	}
 	m1.AssignID()
-	r1.Add(m1)
-	m1.Parent = m0.UUID
-	r2.Add(m1)
-	g.Expect(r1.Data()).Should(gomega.ContainElement(m0.UUID))
-	g.Expect(r2.Data()).ShouldNot(gomega.ContainElement(m0.UUID))
 
-	//m2, _ := NewChatMessage("message 2")
-	//m3, _ := NewChatMessage("message 3")
-	//m4, _ := NewChatMessage("message 4")
-	//m5, _ := NewChatMessage("message 5")
-	//m6, _ := NewChatMessage("message 6")
-	//m7, _ := NewChatMessage("message 7")
-	//m8, _ := NewChatMessage("message 8")
+	for i := 0; i < 7; i++ {
+		r.Add(m1)
+		g.Expect(r.Data()).ShouldNot(gomega.ContainElement(m0.UUID))
+		g.Expect(r.Data()).Should(gomega.ContainElement(m1.UUID))
+		m0 = m1
+		m1, err := m0.Reply("new message")
+		if err != nil {
+			t.Skip("Failed to reply to message")
+		}
+		m1.AssignID()
+	}
 }
 
+// TestRecemtListRemoveParentFull tests that a parent message is replaced when
+// a its child is added to the RecentList, after the queue is full
+func TestRecentListRemoveParentFull(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	r, err := NewRecents(5)
+	if err != nil {
+		t.Skip("Failed to create RecentList", err)
+	}
+
+	// Fill the queue with root messages
+	for i := 0; i < 5; i++ {
+		m1, err := NewChatMessage("new message")
+		if err != nil {
+			t.Skip("Failed to reply to message")
+		}
+		m1.AssignID()
+		r.Add(m1)
+	}
+
+	// Create new root message for replying
+	m0, err := NewChatMessage("message 0")
+	if err != nil {
+		t.Skip("Failed to create message")
+	}
+	m0.AssignID()
+	r.Add(m0)
+
+	// First reply
+	m1, err := m0.Reply("message1")
+	if err != nil {
+		t.Skip("Failed to reply to message")
+	}
+	m1.AssignID()
+
+	// Spin up a bunch of replies
+	for i := 0; i < 7; i++ {
+		r.Add(m1)
+		g.Expect(r.Data()).ShouldNot(gomega.ContainElement(m0.UUID))
+		g.Expect(r.Data()).Should(gomega.ContainElement(m1.UUID))
+		// Shift messages down the queue
+		m0 = m1
+		m1, err := m0.Reply("new message")
+		if err != nil {
+			t.Skip("Failed to reply to message")
+		}
+		m1.AssignID()
+	}
+}
+
+// TestRecentListAddsNewMessages ensure that before and after the queue is
+// full, the newest message is ALWAYS in the list of recents, and that it
+// always replaces the oldest message if the parent is not in the RecentList.
 func TestRecentListAddsNewMessages(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	r, err := NewRecents(5)
@@ -116,4 +173,43 @@ func TestRecentListAddsNewMessages(t *testing.T) {
 	g.Expect(r.Data()).Should(gomega.ContainElement(m8.UUID))
 	g.Expect(r.Data()).Should(gomega.ContainElement(m4.UUID))
 	g.Expect(r.Data()).ShouldNot(gomega.ContainElement(m3.UUID))
+}
+
+// TestWorstCase tests that new messages are being inserted at the head of the
+// queue, even when they replace their parents.
+func TestWorstCase(t *testing.T) {
+	// create a list
+	g := gomega.NewGomegaWithT(t)
+	r, err := NewRecents(3)
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(r).ToNot(gomega.BeNil())
+
+	m0, _ := NewChatMessage("message 0")
+	m0.AssignID()
+	r.Add(m0)
+
+	// fill the list
+	m1, _ := NewChatMessage("message 1")
+	m1.AssignID()
+	r.Add(m1)
+	m2, _ := NewChatMessage("message 2")
+	m2.AssignID()
+	r.Add(m2)
+
+	// reply to the oldest message still in the list
+	m3, _ := m0.Reply("message 3")
+	m3.AssignID()
+	r.Add(m3)
+	g.Expect(r.Data()).Should(gomega.ContainElement(m3.UUID))
+	g.Expect(r.Data()).ShouldNot(gomega.ContainElement(m0.UUID))
+
+	// add a new message to the list
+	m4, _ := NewChatMessage("message 4")
+	m4.AssignID()
+	r.Add(m4)
+	g.Expect(r.Data()).ShouldNot(gomega.ContainElement(m1.UUID))
+
+	g.Expect(r.Data()).Should(gomega.ContainElement(m2.UUID))
+	g.Expect(r.Data()).Should(gomega.ContainElement(m3.UUID))
+	g.Expect(r.Data()).Should(gomega.ContainElement(m4.UUID))
 }

--- a/cmd/arbor/recents_test.go
+++ b/cmd/arbor/recents_test.go
@@ -46,7 +46,7 @@ func TestRecentListRemoveParentVacancy(t *testing.T) {
 	}
 	m0.UUID = "first"
 	r.Add(m0)
-	log.Printf("Adding m0: %s", r.Data())
+	log.Printf("Adding m %s: %s", m0.UUID, r.Data())
 
 	m1, err := m0.Reply("message1")
 	if err != nil {
@@ -56,7 +56,7 @@ func TestRecentListRemoveParentVacancy(t *testing.T) {
 
 	for i := 0; i < 7; i++ {
 		r.Add(m1)
-		log.Printf("Adding m%s: %s", m1.UUID, r.Data())
+		log.Printf("Adding m %s: %s", m1.UUID, r.Data())
 		g.Expect(r.Data()).ShouldNot(gomega.ContainElement(m0.UUID))
 		g.Expect(r.Data()).Should(gomega.ContainElement(m1.UUID))
 		m0 = m1

--- a/cmd/arbor/recents_test.go
+++ b/cmd/arbor/recents_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"testing"
 
+	. "github.com/arborchat/arbor-go"
 	"github.com/onsi/gomega"
 )
 
@@ -10,15 +11,87 @@ import (
 // errors, but that valid sizes produce working RecentLists.
 func TestRecentListConstructor(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
+
 	r, err := NewRecents(-1)
 	g.Expect(err).ToNot(gomega.BeNil())
 	g.Expect(r).To(gomega.BeNil())
+
 	r, err = NewRecents(0)
 	g.Expect(err).ToNot(gomega.BeNil())
 	g.Expect(r).To(gomega.BeNil())
+
 	r, err = NewRecents(1)
 	g.Expect(err).To(gomega.BeNil())
 	g.Expect(r).ToNot(gomega.BeNil())
+
 	data := r.Data()
 	g.Expect(data).To(gomega.BeEmpty())
+}
+
+func TestRecentListRemoveParent(t *testing.T) {
+	//g := gomega.NewGomegaWithT(t)
+	//r, _ := NewRecents(5)
+
+	//m0, _ := NewChatMessage("message 0")
+	//m1, _ := NewChatMessage("message 1")
+	////m1
+	//m2, _ := NewChatMessage("message 2")
+	//m3, _ := NewChatMessage("message 3")
+	//m4, _ := NewChatMessage("message 4")
+	//m5, _ := NewChatMessage("message 5")
+	//m6, _ := NewChatMessage("message 6")
+	//m7, _ := NewChatMessage("message 7")
+	//m8, _ := NewChatMessage("message 8")
+}
+
+func TestRecentListAddsNewMessages(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	r, err := NewRecents(5)
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(r).ToNot(gomega.BeNil())
+
+	m0, _ := NewChatMessage("message 0")
+	m0.AssignID()
+	r.Add(m0)
+	g.Expect(r.Data()).Should(gomega.ContainElement(m0.UUID))
+
+	m1, _ := NewChatMessage("message 1")
+	m1.AssignID()
+	r.Add(m1)
+	g.Expect(r.Data()).Should(gomega.ContainElement(m1.UUID))
+
+	m2, _ := NewChatMessage("message 2")
+	m2.AssignID()
+	r.Add(m2)
+	g.Expect(r.Data()).Should(gomega.ContainElement(m2.UUID))
+
+	m3, _ := NewChatMessage("message 3")
+	m3.AssignID()
+	r.Add(m3)
+	g.Expect(r.Data()).Should(gomega.ContainElement(m3.UUID))
+
+	m4, _ := NewChatMessage("message 4")
+	m4.AssignID()
+	r.Add(m4)
+	g.Expect(r.Data()).Should(gomega.ContainElement(m4.UUID))
+
+	m5, _ := NewChatMessage("message 5")
+	m5.AssignID()
+	r.Add(m5)
+	g.Expect(r.Data()).Should(gomega.ContainElement(m5.UUID))
+
+	m6, _ := NewChatMessage("message 6")
+	m6.AssignID()
+	r.Add(m6)
+	g.Expect(r.Data()).Should(gomega.ContainElement(m6.UUID))
+
+	m7, _ := NewChatMessage("message 7")
+	m7.AssignID()
+	r.Add(m7)
+	g.Expect(r.Data()).Should(gomega.ContainElement(m7.UUID))
+
+	m8, _ := NewChatMessage("message 8")
+	m8.AssignID()
+	r.Add(m8)
+	g.Expect(r.Data()).Should(gomega.ContainElement(m8.UUID))
 }

--- a/cmd/arbor/recents_test.go
+++ b/cmd/arbor/recents_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+)
+
+// TestRecentListConstructor ensures that invalid constructor parameters produce
+// errors, but that valid sizes produce working RecentLists.
+func TestRecentListConstructor(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	r, err := NewRecents(-1)
+	g.Expect(err).ToNot(gomega.BeNil())
+	g.Expect(r).To(gomega.BeNil())
+	r, err = NewRecents(0)
+	g.Expect(err).ToNot(gomega.BeNil())
+	g.Expect(r).To(gomega.BeNil())
+	r, err = NewRecents(1)
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(r).ToNot(gomega.BeNil())
+	data := r.Data()
+	g.Expect(data).To(gomega.BeEmpty())
+}

--- a/cmd/arbor/recents_test.go
+++ b/cmd/arbor/recents_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"testing"
 
 	. "github.com/arborchat/arbor-go"
@@ -46,7 +45,6 @@ func TestRecentListRemoveParentVacancy(t *testing.T) {
 	}
 	m0.UUID = "first"
 	r.Add(m0)
-	log.Printf("Adding m %s: %s", m0.UUID, r.Data())
 
 	m1, err := m0.Reply("message1")
 	if err != nil {
@@ -56,18 +54,14 @@ func TestRecentListRemoveParentVacancy(t *testing.T) {
 
 	for i := 0; i < 7; i++ {
 		r.Add(m1)
-		log.Printf("Adding m %s: %s", m1.UUID, r.Data())
 		g.Expect(r.Data()).ShouldNot(gomega.ContainElement(m0.UUID))
 		g.Expect(r.Data()).Should(gomega.ContainElement(m1.UUID))
 		m0 = m1
-		m1, err := m0.Reply("new message")
+		m1, err = m0.Reply("new message")
 		if err != nil {
 			t.Skip("Failed to reply to message")
 		}
 		m1.UUID = fmt.Sprintf("%dth", i+3)
-		log.Printf("message %d added", i)
-		log.Printf("M0: %s", m0.UUID)
-		log.Printf("M1: %s", m1.UUID)
 	}
 }
 
@@ -112,7 +106,7 @@ func TestRecentListRemoveParentFull(t *testing.T) {
 		g.Expect(r.Data()).Should(gomega.ContainElement(m1.UUID))
 		// Shift messages down the queue
 		m0 = m1
-		m1, err := m0.Reply("new message")
+		m1, err = m0.Reply("new message")
 		if err != nil {
 			t.Skip("Failed to reply to message")
 		}

--- a/cmd/arbor/recents_test.go
+++ b/cmd/arbor/recents_test.go
@@ -46,6 +46,7 @@ func TestRecentListRemoveParentVacancy(t *testing.T) {
 	}
 	m0.UUID = "first"
 	r.Add(m0)
+	log.Printf("Adding m0: %s", r.Data())
 
 	m1, err := m0.Reply("message1")
 	if err != nil {
@@ -55,6 +56,7 @@ func TestRecentListRemoveParentVacancy(t *testing.T) {
 
 	for i := 0; i < 7; i++ {
 		r.Add(m1)
+		log.Printf("Adding m%s: %s", m1.UUID, r.Data())
 		g.Expect(r.Data()).ShouldNot(gomega.ContainElement(m0.UUID))
 		g.Expect(r.Data()).Should(gomega.ContainElement(m1.UUID))
 		m0 = m1

--- a/cmd/arbor/recents_test.go
+++ b/cmd/arbor/recents_test.go
@@ -29,12 +29,26 @@ func TestRecentListConstructor(t *testing.T) {
 }
 
 func TestRecentListRemoveParent(t *testing.T) {
-	//g := gomega.NewGomegaWithT(t)
-	//r, _ := NewRecents(5)
+	g := gomega.NewGomegaWithT(t)
+	r1, _ := NewRecents(5)
+	r2, _ := NewRecents(5)
 
-	//m0, _ := NewChatMessage("message 0")
-	//m1, _ := NewChatMessage("message 1")
-	////m1
+	m0, _ := NewChatMessage("message 0")
+	m0.AssignID()
+	r1.Add(m0)
+	r2.Add(m0)
+
+	// r1 contains m1 with no parent ID
+	// r2 contains m1 with m0 as parent
+	// so m0 should be removed from recents
+	m1, _ := NewChatMessage("message 1")
+	m1.AssignID()
+	r1.Add(m1)
+	m1.Parent = m0.UUID
+	r2.Add(m1)
+	g.Expect(r1.Data()).Should(gomega.ContainElement(m0.UUID))
+	g.Expect(r2.Data()).ShouldNot(gomega.ContainElement(m0.UUID))
+
 	//m2, _ := NewChatMessage("message 2")
 	//m3, _ := NewChatMessage("message 3")
 	//m4, _ := NewChatMessage("message 4")
@@ -79,19 +93,27 @@ func TestRecentListAddsNewMessages(t *testing.T) {
 	m5.AssignID()
 	r.Add(m5)
 	g.Expect(r.Data()).Should(gomega.ContainElement(m5.UUID))
+	g.Expect(r.Data()).Should(gomega.ContainElement(m1.UUID))
+	g.Expect(r.Data()).ShouldNot(gomega.ContainElement(m0.UUID))
 
 	m6, _ := NewChatMessage("message 6")
 	m6.AssignID()
 	r.Add(m6)
 	g.Expect(r.Data()).Should(gomega.ContainElement(m6.UUID))
+	g.Expect(r.Data()).Should(gomega.ContainElement(m2.UUID))
+	g.Expect(r.Data()).ShouldNot(gomega.ContainElement(m1.UUID))
 
 	m7, _ := NewChatMessage("message 7")
 	m7.AssignID()
 	r.Add(m7)
 	g.Expect(r.Data()).Should(gomega.ContainElement(m7.UUID))
+	g.Expect(r.Data()).Should(gomega.ContainElement(m3.UUID))
+	g.Expect(r.Data()).ShouldNot(gomega.ContainElement(m2.UUID))
 
 	m8, _ := NewChatMessage("message 8")
 	m8.AssignID()
 	r.Add(m8)
 	g.Expect(r.Data()).Should(gomega.ContainElement(m8.UUID))
+	g.Expect(r.Data()).Should(gomega.ContainElement(m4.UUID))
+	g.Expect(r.Data()).ShouldNot(gomega.ContainElement(m3.UUID))
 }


### PR DESCRIPTION
I added some documentation to main.go and recents.go. Also, I implemented a simple parent replacement check in dispatch. If the parent of a recent message is currently a "recent message" it should replace the parent with the new message. `RecentList` should now only contain leaf messages.