### PR TITLE
Root flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,6 @@ Run the server with `arbor`. It listens on port 7777 by default, but this can be
 
 #### Flags
 - ruser         Running the server with the flag `-ruser foo` changes the username of the root user. Currently this will only change the root message spawned upon startup. The default username is "root".
-- rid           The `-rid XXXX` flag changes the UUID of the server's root message. The default root message ID is is "".
+- rid           The `-rid XXXX` flag changes the UUID of the server's root message. If unused the server will assign a random UUID to the the root message.
 - rcontent      `-rcontent bar` changes the content of the root message. If left out the root message will say "Welcome to our server!".
 - recent-size   The size of the recent list determines the number of new messages the server has cached to send to new clients upon connection. Starting the server with `-recent-size XXX` changes the starting number of the recents list. This flag **could** effect the optimization of the server. The lists defaults to a capacity of 100 items.

--- a/README.md
+++ b/README.md
@@ -16,4 +16,10 @@ If you'd like to see where things stand, you should be able to do the following:
 go get github.com/arborchat/server/cmd/...
 ```
 
-Run the server with `arbor`, it listens on port 7777 by default.
+Run the server with `arbor`. It listens on port 7777 by default, but this can be changed by running with the port number as the first argument: `arbor 8080`.
+
+#### Flags
+- ruser         Running the server with the flag `-ruser foo` changes the username of the root user. Currently this will only change the root message spawned upon startup. The default username is "root".
+- rid           The `-rid XXXX` flag changes the UUID of the server's root message. The default root message ID is is "".
+- rcontent      `-rcontent bar` changes the content of the root message. If left out the root message will say "Welcome to our server!".
+- recent-size   The size of the recent list determines the number of new messages the server has cached to send to new clients upon connection. Starting the server with `-recent-size XXX` changes the starting number of the recents list. This flag **could** effect the optimization of the server. The lists defaults to a capacity of 100 items.

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ go get github.com/arborchat/server/cmd/...
 
 Run the server with `arbor`. It listens on port 7777 by default, but this can be changed by running with the port number as the first argument: `arbor 8080`.
 
-#### Flags
-- ruser         Running the server with the flag `-ruser foo` changes the username of the root user. Currently this will only change the root message spawned upon startup. The default username is "root".
-- rid           The `-rid XXXX` flag changes the UUID of the server's root message. If unused the server will assign a random UUID to the the root message.
-- rcontent      `-rcontent bar` changes the content of the root message. If left out the root message will say "Welcome to our server!".
-- recent-size   The size of the recent list determines the number of new messages the server has cached to send to new clients upon connection. Starting the server with `-recent-size XXX` changes the starting number of the recents list. This flag **could** effect the optimization of the server. The lists defaults to a capacity of 100 items.
+## Flags
+- **ruser:** Running the server with the flag `-ruser foo` changes the username of the root user. Currently this will only change the root message spawned upon startup. The default username is "root".
+- **rid:** The `-rid XXXX` flag changes the UUID of the server's root message. If unused the server will assign a random UUID to the the root message.
+- **rcontent:**`-rcontent bar` changes the content of the root message. If left out the root message will say "Welcome to our server!".
+- **recent-size:** The size of the recent list determines the number of new messages the server has cached to send to new clients upon connection. Starting the server with `-recent-size XXX` changes the starting number of the recents list. This flag **could** effect the optimization of the server. The lists defaults to a capacity of 100 items.

--- a/cmd/arbor/main.go
+++ b/cmd/arbor/main.go
@@ -1,14 +1,18 @@
 package main
 
 import (
+	"flag"
 	"log"
 	"net"
-	"os"
 
 	. "github.com/arborchat/arbor-go"
 )
 
 func main() {
+	ruser := flag.String("ruser", "root", "The username of the root message")
+	rid := flag.String("rid", "", "The id of the root message")
+	rcontent := flag.String("rcontent", "Welcome to our server!", "The content of the root message")
+	flag.Parse()
 	messages := NewStore()
 	broadcaster := NewBroadcaster()
 	address := ":7777"
@@ -17,22 +21,26 @@ func main() {
 		log.Fatalln("Unable to initialize Recents", err)
 	}
 	//serve
-	if len(os.Args) > 1 {
-		address = os.Args[1]
+	if len(flag.Args()) > 0 {
+		address = flag.Arg(0)
 	}
 	listener, err := net.Listen("tcp", address)
 	if err != nil {
 		log.Fatal(err)
 	}
 	log.Println("Server listening on", address)
-	m, err := NewChatMessage("Welcome to our server!")
+	m, err := NewChatMessage(*rcontent)
 	if err != nil {
 		log.Println(err)
 	}
-	m.Username = "root"
-	err = m.AssignID()
-	if err != nil {
-		log.Println(err)
+	m.Username = *ruser
+	if *rid == "" {
+		err = m.AssignID()
+		if err != nil {
+			log.Println(err)
+		}
+	} else {
+		m.UUID = *rid
 	}
 	messages.Add(m)
 	toWelcome := make(chan chan<- *ProtocolMessage)

--- a/cmd/arbor/main.go
+++ b/cmd/arbor/main.go
@@ -12,11 +12,12 @@ func main() {
 	ruser := flag.String("ruser", "root", "The username of the root message")
 	rid := flag.String("rid", "", "The id of the root message")
 	rcontent := flag.String("rcontent", "Welcome to our server!", "The content of the root message")
+	recentSize := flag.Int("recent-size", 100, "The number of messages to keep in the recents list")
 	flag.Parse()
 	messages := NewStore()
 	broadcaster := NewBroadcaster()
 	address := ":7777"
-	recents, err := NewRecents(10)
+	recents, err := NewRecents(*recentSize)
 	if err != nil {
 		log.Fatalln("Unable to initialize Recents", err)
 	}


### PR DESCRIPTION
This adds a few much-needed flags to the server to control things like the contents of the root message and the number of elements managed by the RecentList.