### PR TITLE
Support protocol 0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: go
 dist: xenial
 install:
     - curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-    - dep ensure
+    - cd cmd/arbor && dep ensure
 script:
     - go test -v -cover ./...

--- a/cmd/arbor/Gopkg.lock
+++ b/cmd/arbor/Gopkg.lock
@@ -2,102 +2,50 @@
 
 
 [[projects]]
-  branch = "meta-0.2"
-  digest = "1:f758740374dbaaaff391c508517f3f0c1ee07d743177b54d4c18de133cfc4ba2"
   name = "github.com/arborchat/arbor-go"
   packages = ["."]
-  pruneopts = "UT"
-  revision = "0fdcaea79431f76954b5801e46079d91949046e2"
+  revision = "29d47f5e0a16373b2055a3c8c7ef0a8a0e370f76"
+  version = "v0.2.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:0e1e5f960c58fdc677212fcc70e55042a0084d367623e51afbdb568963832f5d"
   name = "github.com/nu7hatch/gouuid"
   packages = ["."]
-  pruneopts = "UT"
   revision = "179d4d0c4d8d407a32af483c2354df1d2c91e6c3"
 
 [[projects]]
-  digest = "1:7a137fb7718928e473b7d805434ae563ec41790d3d227cdc64e8b14d1cab8a1f"
   name = "github.com/onsi/gomega"
-  packages = [
-    ".",
-    "format",
-    "internal/assertion",
-    "internal/asyncassertion",
-    "internal/oraclematcher",
-    "internal/testingtsupport",
-    "matchers",
-    "matchers/support/goraph/bipartitegraph",
-    "matchers/support/goraph/edge",
-    "matchers/support/goraph/node",
-    "matchers/support/goraph/util",
-    "types",
-  ]
-  pruneopts = "UT"
+  packages = [".","format","internal/assertion","internal/asyncassertion","internal/oraclematcher","internal/testingtsupport","matchers","matchers/support/goraph/bipartitegraph","matchers/support/goraph/edge","matchers/support/goraph/node","matchers/support/goraph/util","types"]
   revision = "65fb64232476ad9046e57c26cd0bff3d3a8dc6cd"
   version = "v1.4.3"
 
 [[projects]]
-  digest = "1:40e195917a951a8bf867cd05de2a46aaf1806c50cf92eebf4c16f78cd196f747"
   name = "github.com/pkg/errors"
   packages = ["."]
-  pruneopts = "UT"
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:5193d913046443e59093d66a97a40c51f4a5ea4ceba60f3b3ecf89694de5d16f"
   name = "golang.org/x/net"
-  packages = [
-    "html",
-    "html/atom",
-    "html/charset",
-  ]
-  pruneopts = "UT"
+  packages = ["html","html/atom","html/charset"]
   revision = "927f97764cc334a6575f4b7a1584a147864d5723"
 
 [[projects]]
-  digest = "1:aa4d6967a3237f8367b6bf91503964a77183ecf696f1273e8ad3551bb4412b5f"
   name = "golang.org/x/text"
-  packages = [
-    "encoding",
-    "encoding/charmap",
-    "encoding/htmlindex",
-    "encoding/internal",
-    "encoding/internal/identifier",
-    "encoding/japanese",
-    "encoding/korean",
-    "encoding/simplifiedchinese",
-    "encoding/traditionalchinese",
-    "encoding/unicode",
-    "internal/gen",
-    "internal/tag",
-    "internal/utf8internal",
-    "language",
-    "runes",
-    "transform",
-    "unicode/cldr",
-  ]
-  pruneopts = "UT"
+  packages = ["encoding","encoding/charmap","encoding/htmlindex","encoding/internal","encoding/internal/identifier","encoding/japanese","encoding/korean","encoding/simplifiedchinese","encoding/traditionalchinese","encoding/unicode","internal/gen","internal/tag","internal/utf8internal","language","runes","transform","unicode/cldr"]
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
-  digest = "1:4d2e5a73dc1500038e504a8d78b986630e3626dc027bc030ba5c75da257cdb96"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  pruneopts = "UT"
   revision = "51d6538a90f86fe93ac480b35f37b2be17fef232"
   version = "v2.2.2"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  input-imports = [
-    "github.com/arborchat/arbor-go",
-    "github.com/onsi/gomega",
-  ]
+  inputs-digest = "48bca143e1a7dd9e0bb0160c6e1a773e537f4c8f2193cebf9abaf9eb60db86ae"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/arbor/Gopkg.lock
+++ b/cmd/arbor/Gopkg.lock
@@ -2,12 +2,12 @@
 
 
 [[projects]]
-  digest = "1:8daee056790af778375e4ebfd492231e109a253d5350d4d375cbf0e92bfe7ec7"
+  branch = "meta-0.2"
+  digest = "1:f758740374dbaaaff391c508517f3f0c1ee07d743177b54d4c18de133cfc4ba2"
   name = "github.com/arborchat/arbor-go"
   packages = ["."]
   pruneopts = "UT"
-  revision = "c121d4db43986e9e0028225f0ac4a426eea2b89b"
-  version = "v0.1.7"
+  revision = "0fdcaea79431f76954b5801e46079d91949046e2"
 
 [[projects]]
   branch = "master"

--- a/cmd/arbor/Gopkg.toml
+++ b/cmd/arbor/Gopkg.toml
@@ -27,7 +27,7 @@
 
 [[constraint]]
   name = "github.com/arborchat/arbor-go"
-  version = "0.1.7"
+  branch = "meta-0.2"
 
 [[constraint]]
   name = "github.com/onsi/gomega"

--- a/cmd/arbor/Gopkg.toml
+++ b/cmd/arbor/Gopkg.toml
@@ -27,7 +27,7 @@
 
 [[constraint]]
   name = "github.com/arborchat/arbor-go"
-  branch = "meta-0.2"
+  version = "0.2.0"
 
 [[constraint]]
   name = "github.com/onsi/gomega"

--- a/cmd/arbor/main.go
+++ b/cmd/arbor/main.go
@@ -77,7 +77,7 @@ func handleWelcomes(rootId string, recents *RecentList, toWelcome chan arbor.Wri
 			Type:  arbor.WelcomeType,
 			Root:  rootId,
 			Major: 0,
-			Minor: 1,
+			Minor: 2,
 		}
 		msg.Recent = recents.Data()
 
@@ -108,6 +108,8 @@ func handleClient(client arbor.ReadWriteCloser, recents *RecentList, store *arbo
 			go handleQuery(message, client, store)
 		case arbor.NewMessageType:
 			go handleNewMessage(message, recents, store, broadcaster)
+		case arbor.MetaType:
+			broadcaster.Send(message)
 		default:
 			log.Println("Unrecognized message type", message.Type)
 			return


### PR DESCRIPTION
This PR demonstrates adding support for [this](https://github.com/arborchat/protocol/pull/6) draft of the Arbor 0.2 protocol specification. It relies up on [this](https://github.com/arborchat/arbor-go/pull/4) changeset to arbor-go. This PR should not be merged until the 0.2 changes have been added to arbor-go.